### PR TITLE
Add ALPN support in SqueakSSL

### DIFF
--- a/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtos..st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtos..st
@@ -1,0 +1,14 @@
+*HTTP2-Core
+alpnProtos: aProtocolSet
+	| len bytes i |
+	len := 0.
+	aProtocolSet do: [ :x | len := len + 1 + x size ].
+	bytes := ByteArray new: len.
+	i := 1.
+	aProtocolSet do: [ :x |
+		bytes at: i put: x size. 1 to: (x size) do:
+			[ :j | | val |
+				val := x asByteArray at: j.
+				bytes at: i+j put: val ].
+		i := i + 1 + x size ].
+	^ self primitiveSSL: handle setStringProperty: 3 toValue: bytes asString.

--- a/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtos..st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtos..st
@@ -1,14 +1,3 @@
 *HTTP2-Core
 alpnProtos: aProtocolSet
-	| len bytes i |
-	len := 0.
-	aProtocolSet do: [ :x | len := len + 1 + x size ].
-	bytes := ByteArray new: len.
-	i := 1.
-	aProtocolSet do: [ :x |
-		bytes at: i put: x size. 1 to: (x size) do:
-			[ :j | | val |
-				val := x asByteArray at: j.
-				bytes at: i+j put: val ].
-		i := i + 1 + x size ].
-	^ self primitiveSSL: handle setStringProperty: 3 toValue: bytes asString.
+	^ self primitiveSSL: handle setStringProperty: 3 toValue: (self alpnProtosEncode: aProtocolSet).

--- a/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtos.st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtos.st
@@ -1,0 +1,3 @@
+*HTTP2-Core
+alpnProtos
+	^ self primitiveSSL: handle getStringProperty: 3.

--- a/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtosEncode..st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtosEncode..st
@@ -1,14 +1,16 @@
 *HTTP2-Core
 alpnProtosEncode: aProtocolSet
-	| len bytes i |
-	len := 0.
-	aProtocolSet do: [ :x | len := len + 1 + x size ].
-	bytes := ByteArray new: len.
+	| length bytes i |
+	length := 0.
+	aProtocolSet do: [ :protocol | length := length + 1 + protocol size ].
+	
+	bytes := ByteArray new: length.
 	i := 1.
-	aProtocolSet do: [ :x |
-		bytes at: i put: x size. 1 to: (x size) do:
+	aProtocolSet do: [ :protocol |
+		bytes at: i put: protocol size. 1 to: (protocol size) do:
 			[ :j | | val |
-				val := x asByteArray at: j.
+				val := protocol asByteArray at: j.
 				bytes at: i+j put: val ].
-		i := i + 1 + x size ].
+		i := i + 1 + protocol size ].
+	
 	^ bytes asString.

--- a/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtosEncode..st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtosEncode..st
@@ -1,0 +1,14 @@
+*HTTP2-Core
+alpnProtosEncode: aProtocolSet
+	| len bytes i |
+	len := 0.
+	aProtocolSet do: [ :x | len := len + 1 + x size ].
+	bytes := ByteArray new: len.
+	i := 1.
+	aProtocolSet do: [ :x |
+		bytes at: i put: x size. 1 to: (x size) do:
+			[ :j | | val |
+				val := x asByteArray at: j.
+				bytes at: i+j put: val ].
+		i := i + 1 + x size ].
+	^ bytes asString.

--- a/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtosEncode..st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/alpnProtosEncode..st
@@ -7,10 +7,8 @@ alpnProtosEncode: aProtocolSet
 	bytes := ByteArray new: length.
 	i := 1.
 	aProtocolSet do: [ :protocol |
-		bytes at: i put: protocol size. 1 to: (protocol size) do:
-			[ :j | | val |
-				val := protocol asByteArray at: j.
-				bytes at: i+j put: val ].
+		bytes at: i put: protocol size.
+		1 to: (protocol size) do: [ :j | bytes at: i+j put: (protocol asByteArray at: j) ].
 		i := i + 1 + protocol size ].
 	
 	^ bytes asString.

--- a/HTTP2-Core.package/SqueakSSL.extension/instance/alpnSelected.st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/alpnSelected.st
@@ -1,0 +1,3 @@
+*HTTP2-Core
+alpnSelected
+	^ self primitiveSSL: handle getStringProperty: 4.

--- a/HTTP2-Core.package/SqueakSSL.extension/instance/isAlpnSupported.st
+++ b/HTTP2-Core.package/SqueakSSL.extension/instance/isAlpnSupported.st
@@ -1,0 +1,3 @@
+*HTTP2-Core
+isAlpnSupported
+	^ self pluginVersion >= 4

--- a/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
+++ b/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
@@ -4,5 +4,5 @@
 	"instance" : {
 		"alpnProtos" : "tm 5/23/2018 10:53",
 		"alpnProtos:" : "tm 6/5/2018 16:51",
-		"alpnProtosEncode:" : "tm 6/5/2018 16:51",
+		"alpnProtosEncode:" : "tm 6/6/2018 19:20",
 		"alpnSelected" : "tm 6/5/2018 15:49" } }

--- a/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
+++ b/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
@@ -5,4 +5,5 @@
 		"alpnProtos" : "tm 5/23/2018 10:53",
 		"alpnProtos:" : "tm 6/5/2018 16:51",
 		"alpnProtosEncode:" : "tm 6/6/2018 19:24",
-		"alpnSelected" : "tm 6/5/2018 15:49" } }
+		"alpnSelected" : "tm 6/5/2018 15:49",
+		"isAlpnSupported" : "tm 6/11/2018 17:41" } }

--- a/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
+++ b/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"alpnProtos" : "tm 5/23/2018 10:53",
+		"alpnProtos:" : "tm 5/23/2018 11:35" } }

--- a/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
+++ b/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
@@ -3,5 +3,6 @@
 		 },
 	"instance" : {
 		"alpnProtos" : "tm 5/23/2018 10:53",
-		"alpnProtos:" : "tm 5/23/2018 11:35",
+		"alpnProtos:" : "tm 6/5/2018 16:51",
+		"alpnProtosEncode:" : "tm 6/5/2018 16:51",
 		"alpnSelected" : "tm 6/5/2018 15:49" } }

--- a/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
+++ b/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
@@ -3,4 +3,5 @@
 		 },
 	"instance" : {
 		"alpnProtos" : "tm 5/23/2018 10:53",
-		"alpnProtos:" : "tm 5/23/2018 11:35" } }
+		"alpnProtos:" : "tm 5/23/2018 11:35",
+		"alpnSelected" : "tm 6/5/2018 15:49" } }

--- a/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
+++ b/HTTP2-Core.package/SqueakSSL.extension/methodProperties.json
@@ -4,5 +4,5 @@
 	"instance" : {
 		"alpnProtos" : "tm 5/23/2018 10:53",
 		"alpnProtos:" : "tm 6/5/2018 16:51",
-		"alpnProtosEncode:" : "tm 6/6/2018 19:20",
+		"alpnProtosEncode:" : "tm 6/6/2018 19:24",
 		"alpnSelected" : "tm 6/5/2018 15:49" } }

--- a/HTTP2-Core.package/SqueakSSL.extension/properties.json
+++ b/HTTP2-Core.package/SqueakSSL.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "SqueakSSL" }

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/alpnTestProtocolSet.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/alpnTestProtocolSet.st
@@ -1,0 +1,3 @@
+accessing
+alpnTestProtocolSet
+	^ Set with: 'HTTP/1.1' with: 'h2'

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/alpnTestUrl.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/alpnTestUrl.st
@@ -1,0 +1,3 @@
+accessing
+alpnTestUrl
+	^ 'archlinux.org'

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/expectedFailures.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/expectedFailures.st
@@ -1,0 +1,5 @@
+testing
+expectedFailures
+	^ SqueakSSL new isAlpnSupported
+		ifFalse: [Array with: #testALPNSelected with: #testALPNProtosEncoding]
+		ifTrue: [Array new].

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNProtosEncoding.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNProtosEncoding.st
@@ -1,7 +1,6 @@
 testing
 testALPNProtosEncoding
-	| protos ssl |
-	protos := Set with: 'HTTP/1.1' with: 'h2'.
+	| ssl |
 	ssl := SqueakSSL new.
-	ssl alpnProtos: protos.
-	self assert: ssl alpnProtos equals: (ssl alpnProtosEncode: protos).
+	ssl alpnProtos: self alpnTestProtocolSet.
+	self assert: ssl alpnProtos equals: (ssl alpnProtosEncode: self alpnTestProtocolSet).

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNProtosEncoding.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNProtosEncoding.st
@@ -2,5 +2,7 @@ testing
 testALPNProtosEncoding
 	| ssl |
 	ssl := SqueakSSL new.
+	ssl isAlpnSupported
+		ifFalse: [self error: 'SqueakSSL plugin version not supported'].
 	ssl alpnProtos: self alpnTestProtocolSet.
 	self assert: ssl alpnProtos equals: (ssl alpnProtosEncode: self alpnTestProtocolSet).

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNProtosEncoding.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNProtosEncoding.st
@@ -1,0 +1,7 @@
+testing
+testALPNProtosEncoding
+	| protos ssl |
+	protos := Set with: 'HTTP/1.1' with: 'h2'.
+	ssl := SqueakSSL new.
+	ssl alpnProtos: protos.
+	self assert: ssl alpnProtos equals: (ssl alpnProtosEncode: protos).

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
@@ -1,10 +1,11 @@
 testing
 testALPNSelected
-	| protos stream ssl |
-	protos := Set with: 'HTTP/1.1' with: 'h2'.
-	stream := SocketStream openConnectionToHostNamed: 'archlinux.org' port: 443.
+	| stream ssl |
+	self ensureInternetConnectionTo: 'http://', self alpnTestUrl.
+	stream := SocketStream openConnectionToHostNamed: (self alpnTestUrl) port: 443.
 	ssl := SqueakSSL on: stream socket.
+	ssl isAlpnSupported ifFalse: [self error: 'SqueakSSL does not support ALPN'].
 	ssl
-		alpnProtos: protos;
+		alpnProtos: self alpnTestProtocolSet;
 		connect.
-	self assert: (protos includes: ssl alpnSelected).
+	self assert: (self alpnTestProtocolSet includes: ssl alpnSelected).

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
@@ -1,0 +1,10 @@
+testing
+testALPNSelected
+	| protos stream ssl |
+	protos := Set with: 'HTTP/1.1' with: 'h2'.
+	stream := SocketStream openConnectionToHostNamed: 'archlinux.org' port: 443.
+	ssl := SqueakSSL on: stream socket.
+	ssl
+		alpnProtos: protos;
+		connect.
+	self assert: (protos includes: ssl alpnSelected).

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
@@ -4,7 +4,6 @@ testALPNSelected
 	self ensureInternetConnectionTo: 'http://', self alpnTestUrl.
 	stream := SocketStream openConnectionToHostNamed: (self alpnTestUrl) port: 443.
 	ssl := SqueakSSL on: stream socket.
-	ssl isAlpnSupported ifFalse: [self error: 'SqueakSSL does not support ALPN'].
 	ssl
 		alpnProtos: self alpnTestProtocolSet;
 		connect.

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/instance/testALPNSelected.st
@@ -4,6 +4,8 @@ testALPNSelected
 	self ensureInternetConnectionTo: 'http://', self alpnTestUrl.
 	stream := SocketStream openConnectionToHostNamed: (self alpnTestUrl) port: 443.
 	ssl := SqueakSSL on: stream socket.
+	ssl isAlpnSupported
+		ifFalse: [self error: 'SqueakSSL plugin version not supported'].
 	ssl
 		alpnProtos: self alpnTestProtocolSet;
 		connect.

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"testALPNProtosEncoding" : "tm 6/5/2018 16:53",
+		"testALPNSelected" : "tm 6/5/2018 16:55" } }

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
@@ -4,5 +4,6 @@
 	"instance" : {
 		"alpnTestProtocolSet" : "tm 6/11/2018 17:39",
 		"alpnTestUrl" : "tm 6/11/2018 17:39",
+		"expectedFailures" : "tm 6/11/2018 17:57",
 		"testALPNProtosEncoding" : "tm 6/11/2018 17:42",
-		"testALPNSelected" : "tm 6/11/2018 17:45" } }
+		"testALPNSelected" : "tm 6/11/2018 17:55" } }

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
@@ -5,5 +5,5 @@
 		"alpnTestProtocolSet" : "tm 6/11/2018 17:39",
 		"alpnTestUrl" : "tm 6/11/2018 17:39",
 		"expectedFailures" : "tm 6/11/2018 17:57",
-		"testALPNProtosEncoding" : "tm 6/11/2018 17:42",
-		"testALPNSelected" : "tm 6/11/2018 17:55" } }
+		"testALPNProtosEncoding" : "tm 6/12/2018 15:27",
+		"testALPNSelected" : "tm 6/12/2018 15:27" } }

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/methodProperties.json
@@ -2,5 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"testALPNProtosEncoding" : "tm 6/5/2018 16:53",
-		"testALPNSelected" : "tm 6/5/2018 16:55" } }
+		"alpnTestProtocolSet" : "tm 6/11/2018 17:39",
+		"alpnTestUrl" : "tm 6/11/2018 17:39",
+		"testALPNProtosEncoding" : "tm 6/11/2018 17:42",
+		"testALPNSelected" : "tm 6/11/2018 17:45" } }

--- a/HTTP2-Tests.package/H2SqueakSSLTests.class/properties.json
+++ b/HTTP2-Tests.package/H2SqueakSSLTests.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "HTTP2-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "H2SqueakSSLTests",
+	"pools" : [
+		 ],
+	"super" : "TestCase",
+	"type" : "normal" }


### PR DESCRIPTION
Add support for ALPN in SqueakSSL, exposed through `alpnProtos` and `alpnSelected`.
This depends on a [fork of opensmalltalk-vm](https://github.com/hesiod/opensmalltalk-vm/tree/squeakssl-alpn) that supports the required properties in the SqueakSSL plugin.
NB: The fork only supports Linux/OpenSSL at the moment.
This closes #5.